### PR TITLE
Imp quantiles

### DIFF
--- a/R/imputex.R
+++ b/R/imputex.R
@@ -69,9 +69,9 @@ imputex <- function(xmu_formula,
   # note that these are independent draws from the same distribution. Reframe to m vectors:
   draws <- family_fun(object = obsmodel,
                       func = "r",
+                      fitdata = Wdat$obs,
                       predictdata = Wdat$obs,
-                      n = nrow(Wdat$obs)*nrow(Wdat$cens),
-                      fitdata = Wdat$obs)
+                      n = nrow(Wdat$obs)*nrow(Wdat$cens))
   draws <- data.frame(matrix(draws,
                              nrow = nrow(Wdat$obs),
                              ncol = nrow(Wdat$cens)))
@@ -108,10 +108,9 @@ imputex <- function(xmu_formula,
     imputecandidate <- names(boot)[i]
     imputemat[[imputecandidate]] = samplecensored(object = bootmodel[[i]],
                                                   censtype,
+                                                  fitdata = boot,
                                                   predictdata = Wdat$cens,
-                                                  censor,
-                                                  fitdata = boot
-    )
+                                                  censor)
   }
   imputemat$imputedx <- apply(imputemat, MARGIN = 1, mean)
 

--- a/R/imputex.R
+++ b/R/imputex.R
@@ -44,7 +44,7 @@ imputex <- function(xmu_formula,
     stop('data must be non empty data.frame')
   }
 
-  if(!((is.character(indicator)) & (indicator %in% names(data)))){
+  if(!(is.character(indicator) && indicator %in% names(data))){
     stop('indicator must be a column name in data')
   }
 

--- a/R/imputex.R
+++ b/R/imputex.R
@@ -125,21 +125,4 @@ imputex <- function(xmu_formula,
   return(list(imputations = imputemat, fulldata = fulldata)) # edit output format!
 }
 
-d2 <- imputex(data= data,
-             xmu_formula= x1~y+x2,
-             xsigma_formula = ~1,
-             xnu_formula = ~1,
-             xtau_formula = ~1,
-             xfamily = NO(mu.link = 'identity'),
-             indicator = "indicator",
-             censtype = 'right')
 
-# Mit ellipsis geändert
-d3 <- imputex(data= data,
-             xmu_formula= x1~y+x2,
-             xsigma_formula = ~1,
-             xnu_formula = ~1,
-             xtau_formula = ~1,
-             xfamily = NO(mu.link = 'identity'),
-             indicator = "indicator",
-             censtype = 'right',method = CG())

--- a/R/samplecensored.R
+++ b/R/samplecensored.R
@@ -55,7 +55,6 @@ family_fun <- function(object, func, fitdata, predictdata ,p = NULL, q = NULL, x
 # family_fun(gamlssF, func = 'q',predictdata = predict.df, p = 0.5)
 
 
-
 #' @description Inverse sampling of censored variables, to impute only valid observations
 #' conditional on the respective fit
 #' @param object gamlss. Fitted model whose parameters are predicted for predictdata.

--- a/R/samplecensored.R
+++ b/R/samplecensored.R
@@ -17,7 +17,7 @@
 #'
 #' @return Depending on the choice of func, the respective vector of
 #'   (d)density-, (p)cdf.- , (q)quantile- or (r)random values is returned
-family_fun <- function(object, func, predictdata, fitdata ,p = NULL, q = NULL, x = NULL, n = NULL, ...) {
+family_fun <- function(object, func, fitdata, predictdata ,p = NULL, q = NULL, x = NULL, n = NULL, ...) {
 
   # find the correct family function to evaluate
   fam_name = object$family[1]
@@ -47,7 +47,7 @@ family_fun <- function(object, func, predictdata, fitdata ,p = NULL, q = NULL, x
     stop("One of x,q,p,n,... arguments doesn't match with the distributional function
          (e.g. dNO, pNO, qNO, rNO). See the family's documentation for admissable arguments.")
   }
-  return(draw = do.call(f_fun, param))
+  return(do.call(f_fun, param))
   }
 
 # Beispiel für die error message
@@ -89,8 +89,6 @@ samplecensored = function(object, censtype, fitdata, predictdata, censor){  # pr
   }
 }
 
-#' Title
-#'
 #' @param quantiles vector. With desired quantiles
 #' @param object gamlss object
 #' @param fitdata
@@ -105,7 +103,7 @@ impquantiles <- function(quantiles, object, fitdata, predictdata) {
     nrow = nrow(predictdata),
     ncol = length(quantiles)
   ))
-  return(family_fun(object, func = 'p', predictdata, fitdata, q = dquantiles))
+  return(family_fun(object, func = 'p', fitdata, predictdata, q = dquantiles))
 }
 
 

--- a/R/simulatedata.R
+++ b/R/simulatedata.R
@@ -84,8 +84,18 @@ run <- function(censtype,
                color = 'red') +
     geom_point(data = data$truedata[data$truedata[indicator] == 1, ],
                aes(y = y, x = x), color = 'green')
+
   print(p)
-  return(list(data = data, imputex =  d2))
+
+  # fity = fitfull(ymu_formula = y~x1, # hard coded!
+  #                ysigma_formula = y~x2,
+  #                yfamily= NO(link= 'identity'),
+  #                xmu_formula = x1~y,
+  #                xfamily = NO(link = 'identity'),
+  #                data = d2$fulldata,
+  #                indicator = 'inticator',
+  #                censtype = 'right')
+  return(list(data = data, imputex =  d2)) #, fit = fity ))
 }
 
 r = run(

--- a/R/simulatedata.R
+++ b/R/simulatedata.R
@@ -1,19 +1,41 @@
-#'@description Data generator for censored data with Normal distribution
+#'@description Data generator for missing/censored data with Normal distribution
 #'@param n number of generated observations
-#'@param mu.formula
-#'@param sigma.formula
-#'@param family
+#'@param ymu.formula
+#'@param ysigma.formula
+#'
+#'@param family character. Specifies the gamlss family, from which the data is drawn. e.g. 'NO' for
+#'a dependent variable drawn
 #'@return Dataframe, containing covariates, censor indicator and the logit value
 #'pi which is modeled as surrogate for binary decision on Breastcancer
-generateData = function(method ,n, mu.formula = NULL, sigma.formula = NULL, family = NULL){
+simulateData = function(method,
+                        n,
+                        ymu.formula = NULL,
+                        ysigma.formula = NULL,
+                        ynu.formula = NULL,
+                        ytau.formula = NULL,
+                        # formula to defect the data
+                        family) {
+
   # True process
   x = runif(n)
   x1 = x
   x2 = runif(n)
-  y = rnorm(n,mean = eval(mu.formula[[2]]), sd = eval(sigma.formula[[2]]))
+
+  # draw y from family with conditional parameters
+  rfam = paste('r', family, sep = '')
+  param = list(
+    mu = eval(ymu.formula[[2]]),
+    sigma = eval(ysigma.formula[[2]]),
+    nu = eval(ynu.formula[[2]]),
+    tau = eval(ytau.formula[[2]]),
+    n
+  )
+  param = param[!sapply(param, is.null)]
+  y = do.call(rfam, param)
+
   indicator = rbinom(n,1, prob= 0.05)
 
-
+  # alter data according to defect method
   if (method == 'missing'){
     x1[indicator == 1] = NA
   }else if (method == 'right'){
@@ -25,16 +47,26 @@ generateData = function(method ,n, mu.formula = NULL, sigma.formula = NULL, fami
   }else{
     stop('invalid method is specified')
   }
-  return(list(defecteddata = data.frame(y,x1,x2, indicator), truedata = data.frame(y,x,x2, indicator)))
+  return(list(defected = data.frame(y,x1,x2, indicator), truedata = data.frame(y,x,x2, indicator)))
 
 }
 
 # simulated package run
 library(ggplot2)
-run <- function(censtype, indicator, ...) {
-  data = generateData(method = censtype , 1000, ~2*x1 ,~0.5*x2, ...)
+run <- function(censtype,
+                indicator,
+                n,
+                ymu.formula,
+                ysigma.formula,
+                family = 'NO') {
 
-  d2 <- imputex(data = data$defecteddata,
+  data = simulateData(method = censtype ,
+                      n,
+                      ymu.formula,
+                      ysigma.formula,
+                      family = 'NO')
+
+  d2 <- imputex(data = data$defected,
                 xmu_formula= x1~y+x2,
                 xsigma_formula = ~1,
                 xnu_formula = ~1,
@@ -43,12 +75,23 @@ run <- function(censtype, indicator, ...) {
                 indicator = "indicator",
                 censtype )
 
-  ggplot()+
-    geom_point(data = d2$fulldata, aes(y = y , x = x1, color = indicator))+
-    geom_point(data = data$defecteddata[data$defecteddata$indicator == 1,],
-               aes(y = y, x = x1), color = 'red')+
-    geom_point(data = data$truedata[data$truedata$indicator == 1,],
+  # remaster: dataframe usage is not parsimonious
+  # carefull if user specifies more than one dimension.
+  p = ggplot() +
+    geom_point(data = d2$fulldata, aes(y = y , x = x1, color = indicator)) +
+    geom_point(data = data$defected[data$defected[indicator] == 1, ],
+               aes(y = y, x = x1),
+               color = 'red') +
+    geom_point(data = data$truedata[data$truedata[indicator] == 1, ],
                aes(y = y, x = x), color = 'green')
+  print(p)
+  return(list(data = data, imputex =  d2))
 }
 
-run(censtype = 'right', indicator = 'indicator')
+r = run(
+  censtype = 'right',
+  indicator = 'indicator',
+  n = 1000,
+  ymu.formula = ~ 2 * x1 ,
+  ysigma.formula =  ~ 0.5 * x2
+)

--- a/R/simulatedata.R
+++ b/R/simulatedata.R
@@ -7,21 +7,48 @@
 #'pi which is modeled as surrogate for binary decision on Breastcancer
 generateData = function(method ,n, mu.formula = NULL, sigma.formula = NULL, family = NULL){
   # True process
-  x1 = runif(n)
+  x = runif(n)
+  x1 = x
   x2 = runif(n)
   y = rnorm(n,mean = eval(mu.formula[[2]]), sd = eval(sigma.formula[[2]]))
   indicator = rbinom(n,1, prob= 0.05)
-  if (method == 'cens'){
-    x1[indicator == 1] =  1/3 * x1[indicator == 1]
-  } else if (method == 'missing'){
+
+
+  if (method == 'missing'){
     x1[indicator == 1] = NA
+  }else if (method == 'right'){
+    x1[indicator == 1] =  1/3 * x1[indicator == 1]
+  }else if (method == 'left'){
+
+  }else if (method == 'interval'){
+
+  }else{
+    stop('invalid method is specified')
   }
-  return(data.frame(y,x1,x2, indicator))
+  return(list(defecteddata = data.frame(y,x1,x2, indicator), truedata = data.frame(y,x,x2, indicator)))
 
 }
-data = generateData(method = 'cens', 1000, ~2*x1 ,~0.5*x2)
 
+# simulated package run
 library(ggplot2)
-qplot(data = data, y = y , x = x1, color = indicator)
+run <- function(censtype, indicator, ...) {
+  data = generateData(method = censtype , 1000, ~2*x1 ,~0.5*x2, ...)
 
+  d2 <- imputex(data = data$defecteddata,
+                xmu_formula= x1~y+x2,
+                xsigma_formula = ~1,
+                xnu_formula = ~1,
+                xtau_formula = ~1,
+                xfamily = NO(mu.link = 'identity'),
+                indicator = "indicator",
+                censtype )
 
+  ggplot()+
+    geom_point(data = d2$fulldata, aes(y = y , x = x1, color = indicator))+
+    geom_point(data = data$defecteddata[data$defecteddata$indicator == 1,],
+               aes(y = y, x = x1), color = 'red')+
+    geom_point(data = data$truedata[data$truedata$indicator == 1,],
+               aes(y = y, x = x), color = 'green')
+}
+
+run(censtype = 'right', indicator = 'indicator')

--- a/R/temp_plot imputations.R
+++ b/R/temp_plot imputations.R
@@ -1,0 +1,24 @@
+# library(gamlss.cens)
+# gen.cens()
+#
+# x = with(lung, Surv(time, status))
+# ggplot(data = data.frame(x = with(lung, Surv(time, status))), aes(x =x))+
+#   stat_function(fun = dNOrc, args = list(mu = mean(x), sigma = sd(x)))
+# dNOrc(x, mu = mean(x), sigma = sd(x))
+# mean(x)
+
+# (Visualize draws) ------------------------------------------------------------------------------
+require(ggplot2)
+require(reshape2)
+
+df = r$imputex$imputations
+df$observation = seq(1, nrow(df)) # longformat index
+df <- melt(df ,  id.vars = 'observation', variable.name = 'proposalVec')
+
+ggplot(df, aes(observation,value)) +
+  geom_boxplot(aes(group=observation)) +
+  ylab('Proposals for observation [i]')
+
+ggplot(df, aes(observation,value)) +
+  geom_point() +
+  ylab('Proposals for observation [i]')

--- a/R/temp_plot imputations.R
+++ b/R/temp_plot imputations.R
@@ -1,24 +1,41 @@
-# library(gamlss.cens)
-# gen.cens()
+# NOT working example yet
+# data = simulateData(method ='right' ,
+#                     n = 1000,
+#                     ymu.formula = ~ 0.5*x1,
+#                     ysigma.formula ~ 0.3*x2,
+#                     family = 'NO')
 #
-# x = with(lung, Surv(time, status))
-# ggplot(data = data.frame(x = with(lung, Surv(time, status))), aes(x =x))+
-#   stat_function(fun = dNOrc, args = list(mu = mean(x), sigma = sd(x)))
-# dNOrc(x, mu = mean(x), sigma = sd(x))
-# mean(x)
+# d2 <- imputex(data = data$defected,
+#               xmu_formula= x1~y+x2,
+#               xsigma_formula = ~1,
+#               xnu_formula = ~1,
+#               xtau_formula = ~1,
+#               xfamily = NO(mu.link = 'identity'),
+#               indicator = "indicator",
+#               censtype )
 
 # (Visualize draws) ------------------------------------------------------------------------------
 require(ggplot2)
 require(reshape2)
 
-df = r$imputex$imputations
-df$observation = seq(1, nrow(df)) # longformat index
-df <- melt(df ,  id.vars = 'observation', variable.name = 'proposalVec')
+# make it a class method!
+plotimputations <- function(df, boxes = TRUE) {
 
-ggplot(df, aes(observation,value)) +
-  geom_boxplot(aes(group=observation)) +
-  ylab('Proposals for observation [i]')
+  # Convert to Longformat
+  df$observation = seq(1, nrow(df))
+  df <- melt(df ,  id.vars = 'observation', variable.name = 'proposalVec')
 
-ggplot(df, aes(observation,value)) +
-  geom_point() +
-  ylab('Proposals for observation [i]')
+  if (boxes) {
+    return(ggplot(df, aes(observation, value)) +
+             geom_boxplot(aes(group = observation)) +
+             ylab('Proposals for observation [i]'))
+  }else {
+    return(ggplot(df, aes(observation, value)) +
+             geom_point() +
+             ylab('Proposals for observation [i]'))
+  }
+}
+
+plotimputations(r$imputex$imputations[, -ncol(r$imputex$imputations)],
+                boxes = FALSE)  # the imputed value is ommited
+


### PR DESCRIPTION
Patch: 
(1) tmp_plotimputations als funktion, die von imputex die imputmat abgreift und plottet
Sie soll aber noch mit einem imputed class object arbeiten können und dann in Methods 

(2) imputex, samplecensored & family_fun werden nur mit positional reference gecallt nicht mit passes wie data = data

(3) impquantiles als modul besteht schon und kann ggf. bei imputex --> for() --> nach bootmodel eingepflegt werden. dann müssen nur die resulting quantiles aufgefangen und ausgewertet werden. 
oder aber Alternativ, können auch die params der bootmodelliste geaveraged werden und dann mittels der average parameter eine "average distribution" in family fun ausgewertet werden.

(4) simulate data ist flexibler gestaltet. aber die censored branches bedürfen noch arbeit, nach welchem schema genau die einzelnen censorings erzeugt werden sollen.

(5) run funktion; generiert censored/missing data, imputed und anschließend wird der Datensatz samt censored/imputed geplottet. hier fehlt noch die erweiterung um das distribution quantile von (3)
zudem soll noch fitfull (also y fit) in dem run implementiert werden.