### PR TITLE
Average quantiles on the valid regions for censored data

### DIFF
--- a/R/imputex.R
+++ b/R/imputex.R
@@ -47,7 +47,7 @@ imputex <- function(xmu_formula,
   # split dataset in fully observed & missing/censored data
   Wdat <- W(data, indicator)
   censor <- as.character(xmu_formula[[2]])
-  
+
   # Algorithm --------------------------------------------------------------------
 
   # Step 1: fit gamlss with user specified xfamily and formula on observed data
@@ -84,6 +84,7 @@ imputex <- function(xmu_formula,
   # step 3 estimate param. on each respective set {x*boot(j), W_obs} for all j
   bootmodel <- list()
   imputemat <- data.frame(X1 = vector(length= nrow(Wdat$cens)))
+  imputeq = list()
   for (i in 1:ncol(draws)){
     # iterate only over the names of booted vectors.
 
@@ -103,36 +104,42 @@ imputex <- function(xmu_formula,
 
     # Simulate data from the corresponding fitted distribution.
     imputecandidate <- names(boot)[i]
-    imputemat[[imputecandidate]] = samplecensored(object = bootmodel[[i]],
-                                                  censtype,
-                                                  fitdata = boot,
-                                                  predictdata = Wdat$cens,
-                                                  censor)
+    impute = samplecensored(object = bootmodel[[i]],
+                            censtype,
+                            fitdata = boot,
+                            predictdata = Wdat$cens,
+                            censor)
+    imputemat[[imputecandidate]] = impute$draw
+    imputeq[[i]] = impute$quantiles
   }
+  # imputed vector
   imputemat$imputedx <- apply(imputemat, MARGIN = 1, mean)
 
   # complete data with imputations
-
-
   Wdat$cens[censor] <- imputemat$imputedx
   fulldata <- rbind(Wdat$obs,Wdat$cens)
-  
+
   # variability of imputed vectors
   imputevariance = apply(imputemat[,-ncol(imputemat)], MARGIN = 1, FUN = var)
 
+  # average imputed quantiles
+  A = array(unlist(imputeq), dim = c(nrow(imputeq[[1]]), ncol(imputeq[[1]]), length(imputeq)))
+  impquantiles = apply(A, c(1,2), mean)
+
   mcall <- match.call()
-  
+
   result <- list(imputations = imputemat,
                  fulldata = fulldata,
                  mcall = mcall,
                  number_of_imputations = nrow(Wdat$cens),
                  censoring_type = censtype,
                  number_of_observations = nrow(Wdat$obs) + nrow(Wdat$cens),
-                 imputevariance = imputevariance)
-  
-  #  Create a class for this kind of result 
+                 imputevariance = imputevariance,
+                 impquantiles = impquantiles)
+
+  #  Create a class for this kind of result
    class(result) <- "imputed"
-   
-  return(result) 
+
+  return(result)
 }
 

--- a/R/imputex.R
+++ b/R/imputex.R
@@ -85,6 +85,7 @@ imputex <- function(xmu_formula,
   bootmodel <- list()
   imputemat <- data.frame(X1 = vector(length= nrow(Wdat$cens)))
   imputeq = list()
+  quantil = c(0.05, 0.25, 0.5, 0.75, 0.95)
   for (i in 1:ncol(draws)){
     # iterate only over the names of booted vectors.
 
@@ -108,7 +109,8 @@ imputex <- function(xmu_formula,
                             censtype,
                             fitdata = boot,
                             predictdata = Wdat$cens,
-                            censor)
+                            censor,
+                            quantil)
     imputemat[[imputecandidate]] = impute$draw
     imputeq[[i]] = impute$quantiles
   }
@@ -124,7 +126,8 @@ imputex <- function(xmu_formula,
 
   # average imputed quantiles
   A = array(unlist(imputeq), dim = c(nrow(imputeq[[1]]), ncol(imputeq[[1]]), length(imputeq)))
-  impquantiles = apply(A, c(1,2), mean)
+  impquantiles = as.data.frame(apply(A, c(1,2), mean))
+  colnames(impquantiles) = c('q5','q25','q50', 'q75', 'q95' )
 
   mcall <- match.call()
 

--- a/R/samplecensored.R
+++ b/R/samplecensored.R
@@ -77,7 +77,7 @@ samplecensored = function(object, censtype, predictdata, fitdata, censor, quanti
     pindex = family_fun(object, func = 'p', fitdata, predictdata, q = predictdata[[censor]])
     psample = runif(n = nrow(predictdata), min = pindex, max = 1)
 
-    # (quatniles)
+    # (quantiles)
     quantprob = as.data.frame(matrix(rep(quantiles, times = length(pindex)), byrow = TRUE, nrow = length(pindex)))
     qindex = (1-pindex)*quantprob + pindex
 

--- a/R/samplecensored.R
+++ b/R/samplecensored.R
@@ -51,11 +51,6 @@ family_fun <- function(object, func, fitdata, predictdata ,p = NULL, q = NULL, x
   return(do.call(f_fun, param))
   }
 
-# Beispiel f?r die error message
-# family_fun(gamlssF, func = 'q',predictdata = predict.df, x = 0)
-# family_fun(gamlssF, func = 'q',predictdata = predict.df, p = 0.5)
-
-
 #' @title Inverse sampling - GAMLSS
 #' @description Inverse sampling of censored variables, to impute only valid observations
 #' conditional on the respective fit

--- a/R/samplecensored.R
+++ b/R/samplecensored.R
@@ -63,7 +63,7 @@ family_fun <- function(object, func, fitdata, predictdata ,p = NULL, q = NULL, x
 #' is only required if censtype is NOT 'missing'.
 #' @return WRITE HERE WHAT TO BE RETURNED
 #' @export
-samplecensored = function(object, censtype, predictdata, fitdata, censor, quantiles = c(0.05, 0.95)){
+samplecensored = function(object, censtype, predictdata, fitdata, censor, quantiles = c(0.05, 0.25, 0.5, 0.75, 0.95)){
 
   if(censtype == 'missing'){
     # qindex does not require scaling!
@@ -99,36 +99,18 @@ samplecensored = function(object, censtype, predictdata, fitdata, censor, quanti
   quantprob = as.data.frame(matrix(rep(quantiles, times = length(pindex)),
                                    byrow = TRUE, nrow = length(pindex)))
   qindex = (1-pindex)*quantprob + pindex
-
+  quantiles = apply(
+    qindex,
+    MARGIN = 2,
+    FUN = function(q)
+      family_fun(object, func = 'q', fitdata, predictdata, p = q)
+  )
+  colnames(quantiles) = quantiles
   return(list(
     draw = draw,
-    quantiles = apply(
-      qindex,
-      MARGIN = 2,
-      FUN = function(q)
-        family_fun(object, func = 'q', fitdata, predictdata, p = q)
-    )
+    quantiles = quantiles
   ))
 }
-
-#' @param quantiles vector. With desired quantiles
-#' @param object gamlss object
-#' @param fitdata
-#' @param predictdata
-#'
-#' @return WRITE
-#' @export
-impquantiles <- function(quantiles, object, fitdata, predictdata) {
-  # rowwise repeat the vector by the length of imputations to use family_fun
-  dquantiles = data.frame(matrix(
-    quantiles,
-    byrow = T,
-    nrow = nrow(predictdata),
-    ncol = length(quantiles)
-  ))
-  return(family_fun(object, func = 'p', fitdata, predictdata, q = dquantiles))
-}
-
 
 
 

--- a/R/samplecensored.R
+++ b/R/samplecensored.R
@@ -68,7 +68,7 @@ family_fun <- function(object, func, fitdata, predictdata ,p = NULL, q = NULL, x
 #' is only required if censtype is NOT 'missing'.
 #' @return WRITE HERE WHAT TO BE RETURNED
 #' @export
-samplecensored = function(object, censtype, predictdata, fitdata, censor){  # predictdata is W$obs/W$mis, an denen die fitted values predicted werden, um anschlie?end p auszuwerten
+samplecensored = function(object, censtype, predictdata, fitdata, censor, quantiles = c(0.05, 0.95)){  # predictdata is W$obs/W$mis, an denen die fitted values predicted werden, um anschlie?end p auszuwerten
 
   if(censtype == 'missing'){
     return(family_fun(object, func = 'r', fitdata, predictdata, n = nrow(predictdata)))
@@ -76,7 +76,13 @@ samplecensored = function(object, censtype, predictdata, fitdata, censor){  # pr
   }else if(censtype == 'right'){
     pindex = family_fun(object, func = 'p', fitdata, predictdata, q = predictdata[[censor]])
     psample = runif(n = nrow(predictdata), min = pindex, max = 1)
-    return(family_fun(object, func =  'q', fitdata, predictdata, p = psample))
+
+    # (quatniles)
+    quantprob = matrix(rep(quantiles, times = length(pindex)), byrow = TRUE, nrow = length(pindex))
+    qindex = (1-pindex)*quantprob + (1-pindex)
+    family_fun(object, func = 'q', fitdata, predictdata, p = qindex)
+
+    return(list(draw = family_fun(object, func =  'q', fitdata, predictdata, p = psample), quantiles = quantiles))
 
   }else if (censtype == 'left'){
     pindex = family_fun(object, func = 'p', fitdata, predictdata, q = predictdata[[censor]])

--- a/R/temp_plot imputations.R
+++ b/R/temp_plot imputations.R
@@ -1,19 +1,3 @@
-# NOT working example yet
-# data = simulateData(method ='right' ,
-#                     n = 1000,
-#                     ymu.formula = ~ 0.5*x1,
-#                     ysigma.formula ~ 0.3*x2,
-#                     family = 'NO')
-#
-# d2 <- imputex(data = data$defected,
-#               xmu_formula= x1~y+x2,
-#               xsigma_formula = ~1,
-#               xnu_formula = ~1,
-#               xtau_formula = ~1,
-#               xfamily = NO(mu.link = 'identity'),
-#               indicator = "indicator",
-#               censtype )
-
 # (Visualize draws) ------------------------------------------------------------------------------
 require(ggplot2)
 require(reshape2)
@@ -26,16 +10,17 @@ plotimputations <- function(df, boxes = TRUE) {
   df <- melt(df ,  id.vars = 'observation', variable.name = 'proposalVec')
 
   if (boxes) {
-    return(ggplot(df, aes(observation, value)) +
+    return(ggplot(data = subset(df, df$proposalVec != 'imputedx'), aes(observation, value)) +
              geom_boxplot(aes(group = observation)) +
-             ylab('Proposals for observation [i]'))
+             geom_point(data = subset(df, df$proposalVec == 'imputedx'), aes(observation, value, color = 'red'))+
+             ylab('Proposals for observation [i]')) # NOTE that red dots are based on mean, boxes display median.
   }else {
-    return(ggplot(df, aes(observation, value)) +
-             geom_point() +
+    return(ggplot() +
+             geom_point(data = subset(df, df$proposalVec != 'imputedx'), aes(observation, value)) +
+             geom_point(data = subset(df, df$proposalVec == 'imputedx'), aes(observation, value, color = proposalVec))+
              ylab('Proposals for observation [i]'))
   }
 }
 
-plotimputations(r$imputex$imputations[, -ncol(r$imputex$imputations)],
+plotimputations(d2$imputations[, -ncol(r$imputex$imputations)],
                 boxes = FALSE)  # the imputed value is ommited
-

--- a/R/temp_plot imputations.R
+++ b/R/temp_plot imputations.R
@@ -3,24 +3,39 @@ require(ggplot2)
 require(reshape2)
 
 # make it a class method!
-plotimputations <- function(df, boxes = TRUE) {
+plotimputations <- function(object, boxes = TRUE, quantiles = FALSE) {
+  df = object$imputations
+  if(quantiles == TRUE){
+    print(ggplot(object$impquantiles,
+                 aes(x = seq(1:nrow(d2$impquantiles)),
+                     ymin=q5,
+                     lower=q25,
+                     middle=q50,
+                     upper=q75,
+                     ymax=q95)) +
+            geom_boxplot(stat="identity")+
+            xlab('draw'))
+  }
+
 
   # Convert to Longformat
   df$observation = seq(1, nrow(df))
   df <- melt(df ,  id.vars = 'observation', variable.name = 'proposalVec')
 
   if (boxes) {
-    return(ggplot(data = subset(df, df$proposalVec != 'imputedx'), aes(observation, value)) +
+    print( ggplot(data = subset(df, df$proposalVec != 'imputedx'), aes(observation, value)) +
              geom_boxplot(aes(group = observation)) +
              geom_point(data = subset(df, df$proposalVec == 'imputedx'), aes(observation, value, color = 'red'))+
              ylab('Proposals for observation [i]')) # NOTE that red dots are based on mean, boxes display median.
   }else {
-    return(ggplot() +
+    print( ggplot() +
              geom_point(data = subset(df, df$proposalVec != 'imputedx'), aes(observation, value)) +
              geom_point(data = subset(df, df$proposalVec == 'imputedx'), aes(observation, value, color = proposalVec))+
              ylab('Proposals for observation [i]'))
   }
 }
 
-plotimputations(d2$imputations[, -ncol(r$imputex$imputations)],
-                boxes = FALSE)  # the imputed value is ommited
+# quantiles should be highly skewed
+plotimputations(d2, boxes = FALSE, quantiles = TRUE)  # the imputed value is ommited
+
+


### PR DESCRIPTION
The main new feature implemented here are the average quantiles. 
It is theoretically and computationally more demanding to arrive at a proper solution for the quantiles of the distributions from which each censored observation is drawn, even though the parameters are available for the uncensored versions of those distributions. However, this patch provides a proxy for those quantilies. Following the inverse sampling implementation earlier, the conditional cdf of each observation is already available. The valid region for draws from the distribution is determined by the information contained in the censoring. This part of the cdf is then rescaled to suffice the requirements of a probability distribution. Once the region is rescaled, the quantiles of each observation's distribution can be easily evaluated from the cdf. As we proceed like this for all proposal vectors (imputations), we can average the quantilies for each observation respectively to arrive at an average quantile, that is provided along with the averaged final impuation vector.

Furthermore, these quantiles can now be plotted.

